### PR TITLE
`FormatMoney` function.

### DIFF
--- a/src/Money/formatMoney.js
+++ b/src/Money/formatMoney.js
@@ -1,0 +1,35 @@
+/*
+ * Wrapper for money representation. Uses `Number.prototype.toLocaleString`
+ * under the hood.
+ */
+const FormatMoney = function FormatMoney(
+ amountInCents, locales, currency, options={}, precision=2
+) {
+  if (locales == null) {
+    throw new Error("locales must be provided");
+  }
+
+  if (currency == null) {
+    throw new Error("currency must be provided");
+  }
+
+  const VIEW_OPTIONS = {
+    currency:              currency,
+    style:                 'currency',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2
+  }
+
+  function toString() {
+    const localeOptions = Object.assign({}, VIEW_OPTIONS, options);
+    return amountInFixedPoint().toLocaleString(locales, localeOptions);
+  }
+
+  function amountInFixedPoint() {
+    return (amountInCents / Math.pow(10, precision));
+  }
+
+  return toString();
+}
+
+export default FormatMoney;

--- a/src/Money/formatMoney.test.js
+++ b/src/Money/formatMoney.test.js
@@ -1,0 +1,44 @@
+import test  from 'tape';
+import Money from './money';
+
+test('Money correctly parses amounts in cents',
+  function testMoneyToStringIfAmountLessThan3Digits(assert) {
+    assert.plan(1)
+    const amount = 10;
+    const money = Money(amount, testLocale, testCurrency);
+    assert.equal(money, '£0.10')
+  }
+);
+test('Money correctly parses amounts in cents with custom precision',
+  function testMoneyToStringWithCustomPrecision(assert) {
+    assert.plan(1)
+    const amount    = 1023;
+    const precision = 4;
+    const options   = {
+      maximumFractionDigits: precision,
+      minimumFractionDigits: precision
+    };
+    const money = Money(amount, testLocale, testCurrency, options, precision);
+    assert.equal(money, '£0.1023');
+  }
+);
+
+test('Money requires locales argument',
+  function testLocalesRequirement(assert) {
+    assert.plan(1);
+    assert.throws(function() {
+      Money(10);
+    });
+  }
+);
+test('Money requires currency argument',
+  function testCurrencyRequirement(assert) {
+    assert.plan(1);
+    assert.throws(function() {
+      Money(10, testLocale);
+    });
+  }
+);
+
+const testLocale   = 'en-GB';
+const testCurrency = 'GBP';


### PR DESCRIPTION
We will want to have such a function for pretty-formating amount outputted by our backend (in a format of cents). There is built-in really useful `Number.prototype.toLocaleString` function that makes the hardest part for us.

The only possible problem is that it requires some kind of polyfill on Safari Webkit, IE < 11 and most mobile browsers.

I leave it here working and not documented. However before merging, we must find some way to make it more universal for browsers not supporting this function.
